### PR TITLE
docs: add Docker Desktop Kubernetes deployment docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.venv
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+*.db
+*.sqlite3
+.git
+.gitignore
+.pytest_cache
+.ruff_cache
+README.md
+deploy.md
+k8-learning.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/app/main.py
+++ b/app/main.py
@@ -14,4 +14,10 @@ app = FastAPI(
     version="1.0.0"
 )
 
+
+@app.get("/health")
+def health_check():
+    return {"status": "ok"}
+
+
 app.include_router(url_router.router)

--- a/deploy.md
+++ b/deploy.md
@@ -1,0 +1,161 @@
+# Deploy URL Shortener on Docker Desktop Kubernetes
+
+This guide deploys the FastAPI URL Shortener to the single-node Kubernetes cluster that ships with Docker Desktop.
+
+## What You Will Run
+
+- FastAPI app served by Uvicorn on port `8000`
+- Docker image named `url-shortener:dev`
+- Kubernetes `Deployment` with one replica
+- Kubernetes `Service` exposed on `http://localhost:30080`
+- SQLite database stored in an `emptyDir` volume at `/data/url_shortener.db`
+
+`emptyDir` is good for learning because it is simple, but the data disappears when the Pod is deleted. Later, replace it with a `PersistentVolumeClaim`.
+
+## Prerequisites
+
+1. Install Docker Desktop.
+2. Enable Kubernetes:
+   - Docker Desktop -> Settings -> Kubernetes -> Enable Kubernetes
+3. Confirm your context points to Docker Desktop:
+
+```bash
+kubectl config current-context
+```
+
+Expected context:
+
+```text
+docker-desktop
+```
+
+If needed:
+
+```bash
+kubectl config use-context docker-desktop
+```
+
+## 1. Build the Docker Image
+
+Run this from the project root:
+
+```bash
+docker build -t url-shortener:dev .
+```
+
+Smoke test the image locally:
+
+```bash
+docker run --rm -p 8000:8000 url-shortener:dev
+```
+
+Open:
+
+```text
+http://localhost:8000
+```
+
+Stop the container with `Ctrl+C`.
+
+## 2. Deploy to Kubernetes
+
+Apply the manifests:
+
+```bash
+kubectl apply -f k8s/namespace.yaml
+kubectl apply -f k8s/deployment.yaml
+kubectl apply -f k8s/service.yaml
+```
+
+Check the rollout:
+
+```bash
+kubectl rollout status deployment/url-shortener -n url-shortener
+```
+
+Check the resources:
+
+```bash
+kubectl get all -n url-shortener
+```
+
+## 3. Open the App
+
+Docker Desktop exposes `NodePort` services on localhost.
+
+Open:
+
+```text
+http://localhost:30080
+```
+
+Try shortening a URL, then click the generated short URL.
+
+## 4. Useful Debug Commands
+
+List Pods:
+
+```bash
+kubectl get pods -n url-shortener
+```
+
+Describe the Deployment:
+
+```bash
+kubectl describe deployment url-shortener -n url-shortener
+```
+
+Describe a Pod:
+
+```bash
+kubectl describe pod <pod-name> -n url-shortener
+```
+
+View logs:
+
+```bash
+kubectl logs deployment/url-shortener -n url-shortener
+```
+
+Open a shell inside the Pod:
+
+```bash
+kubectl exec -it deployment/url-shortener -n url-shortener -- sh
+```
+
+Check the health endpoint from your machine:
+
+```bash
+curl http://localhost:30080/health
+```
+
+## 5. Update the App
+
+After changing Python or template files:
+
+```bash
+docker build -t url-shortener:dev .
+kubectl rollout restart deployment/url-shortener -n url-shortener
+kubectl rollout status deployment/url-shortener -n url-shortener
+```
+
+Because the manifest uses `imagePullPolicy: Never`, Kubernetes uses the local Docker Desktop image.
+
+## 6. Clean Up
+
+Delete the app:
+
+```bash
+kubectl delete namespace url-shortener
+```
+
+This also deletes the `emptyDir` SQLite data.
+
+## 7. Next Production Improvements
+
+- Replace `emptyDir` with a `PersistentVolumeClaim`.
+- Use a real database such as PostgreSQL.
+- Add resource requests and limits.
+- Add Ingress instead of `NodePort`.
+- Add CI to build and push images.
+- Add tests before every image build.

--- a/k8-learning.md
+++ b/k8-learning.md
@@ -1,0 +1,474 @@
+# Kubernetes Break/Fix Learning Path
+
+Use this file as a hands-on tutorial for learning Kubernetes by breaking this real URL Shortener app and fixing it again.
+
+Start from a healthy deployment:
+
+```bash
+docker build -t url-shortener:dev .
+kubectl apply -f k8s/namespace.yaml
+kubectl apply -f k8s/deployment.yaml
+kubectl apply -f k8s/service.yaml
+kubectl rollout status deployment/url-shortener -n url-shortener
+curl http://localhost:30080/health
+```
+
+Expected response:
+
+```json
+{"status":"ok"}
+```
+
+## Learning Loop
+
+For each exercise:
+
+1. Break one thing.
+2. Observe symptoms with `kubectl get`, `kubectl describe`, `kubectl logs`, and `curl`.
+3. Explain what Kubernetes is telling you.
+4. Fix the manifest or rebuild the image.
+5. Confirm the app works again.
+
+## Exercise 1: Wrong Image Name
+
+Goal: Learn `ImagePullBackOff`.
+
+Break it:
+
+```bash
+kubectl set image deployment/url-shortener url-shortener=url-shortener:missing -n url-shortener
+kubectl get pods -n url-shortener
+```
+
+Observe:
+
+```bash
+kubectl describe pod <pod-name> -n url-shortener
+```
+
+Expected symptom:
+
+```text
+ErrImageNeverPull
+```
+
+Why it broke:
+
+The Deployment uses `imagePullPolicy: Never`, so Kubernetes expects the image to already exist inside Docker Desktop. `url-shortener:missing` does not exist locally.
+
+Fix it:
+
+```bash
+kubectl set image deployment/url-shortener url-shortener=url-shortener:dev -n url-shortener
+kubectl rollout status deployment/url-shortener -n url-shortener
+curl http://localhost:30080/health
+```
+
+## Exercise 2: Wrong Container Port
+
+Goal: Learn the difference between `containerPort`, `targetPort`, and app runtime port.
+
+Break it by editing `k8s/service.yaml`:
+
+```yaml
+targetPort: 9999
+```
+
+Apply:
+
+```bash
+kubectl apply -f k8s/service.yaml
+curl http://localhost:30080/health
+```
+
+Expected symptom:
+
+```text
+Connection refused
+```
+
+Observe:
+
+```bash
+kubectl get endpoints url-shortener -n url-shortener
+kubectl describe service url-shortener -n url-shortener
+```
+
+Why it broke:
+
+The FastAPI app listens on port `8000` inside the container. The Service sent traffic to port `9999`, where nothing is listening.
+
+Fix it:
+
+```yaml
+targetPort: 8000
+```
+
+Apply and test:
+
+```bash
+kubectl apply -f k8s/service.yaml
+curl http://localhost:30080/health
+```
+
+## Exercise 3: Selector Mismatch
+
+Goal: Learn how Services find Pods.
+
+Break it by editing `k8s/service.yaml`:
+
+```yaml
+selector:
+  app: wrong-app
+```
+
+Apply:
+
+```bash
+kubectl apply -f k8s/service.yaml
+kubectl get endpoints url-shortener -n url-shortener
+```
+
+Expected symptom:
+
+```text
+ENDPOINTS   <none>
+```
+
+Why it broke:
+
+The Service only routes to Pods whose labels match its selector. The Pods are labeled `app: url-shortener`, but the Service searched for `app: wrong-app`.
+
+Fix it:
+
+```yaml
+selector:
+  app: url-shortener
+```
+
+Apply and test:
+
+```bash
+kubectl apply -f k8s/service.yaml
+curl http://localhost:30080/health
+```
+
+## Exercise 4: Readiness Probe Failure
+
+Goal: Learn why a running Pod may still receive no traffic.
+
+Break it by editing `k8s/deployment.yaml`:
+
+```yaml
+readinessProbe:
+  httpGet:
+    path: /not-health
+    port: 8000
+```
+
+Apply:
+
+```bash
+kubectl apply -f k8s/deployment.yaml
+kubectl get pods -n url-shortener
+kubectl describe pod <pod-name> -n url-shortener
+```
+
+Expected symptom:
+
+```text
+READY   0/1
+Readiness probe failed: HTTP probe failed with statuscode: 404
+```
+
+Why it broke:
+
+The app has `/health`, but the readiness probe checks `/not-health`. Kubernetes keeps the Pod out of Service endpoints because it is not ready.
+
+Fix it:
+
+```yaml
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 8000
+```
+
+Apply and test:
+
+```bash
+kubectl apply -f k8s/deployment.yaml
+kubectl rollout status deployment/url-shortener -n url-shortener
+curl http://localhost:30080/health
+```
+
+## Exercise 5: Liveness Probe Restart Loop
+
+Goal: Learn restart behavior caused by health checks.
+
+Break it by editing `k8s/deployment.yaml`:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /not-health
+    port: 8000
+  initialDelaySeconds: 5
+  periodSeconds: 5
+```
+
+Apply:
+
+```bash
+kubectl apply -f k8s/deployment.yaml
+kubectl get pods -n url-shortener --watch
+```
+
+Expected symptom:
+
+The Pod repeatedly restarts.
+
+Observe:
+
+```bash
+kubectl describe pod <pod-name> -n url-shortener
+kubectl logs <pod-name> -n url-shortener --previous
+```
+
+Why it broke:
+
+The liveness probe tells Kubernetes when the container should be restarted. A bad path makes Kubernetes think the healthy app is dead.
+
+Fix it:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 8000
+  initialDelaySeconds: 15
+  periodSeconds: 20
+```
+
+Apply and test:
+
+```bash
+kubectl apply -f k8s/deployment.yaml
+kubectl rollout status deployment/url-shortener -n url-shortener
+```
+
+## Exercise 6: Bad Database Path
+
+Goal: Learn environment variables, volume mounts, and app startup failures.
+
+Break it by editing `k8s/deployment.yaml`:
+
+```yaml
+env:
+  - name: DATABASE_URL
+    value: sqlite:////missing-folder/url_shortener.db
+```
+
+Apply:
+
+```bash
+kubectl apply -f k8s/deployment.yaml
+kubectl get pods -n url-shortener
+kubectl logs deployment/url-shortener -n url-shortener
+```
+
+Expected symptom:
+
+The app may fail when it tries to create or write to the SQLite database.
+
+Why it broke:
+
+The app reads `DATABASE_URL` from the container environment. The configured path points to a folder that is not mounted and may not exist.
+
+Fix it:
+
+```yaml
+env:
+  - name: DATABASE_URL
+    value: sqlite:////data/url_shortener.db
+volumeMounts:
+  - name: sqlite-data
+    mountPath: /data
+```
+
+Apply and test:
+
+```bash
+kubectl apply -f k8s/deployment.yaml
+curl http://localhost:30080/health
+```
+
+## Exercise 7: Delete the Pod
+
+Goal: Learn how Deployments self-heal.
+
+Break it:
+
+```bash
+kubectl delete pod <pod-name> -n url-shortener
+kubectl get pods -n url-shortener --watch
+```
+
+Expected symptom:
+
+Kubernetes creates a replacement Pod.
+
+Why it recovered:
+
+The Deployment owns a ReplicaSet, and the ReplicaSet keeps the desired number of Pods running.
+
+Confirm:
+
+```bash
+curl http://localhost:30080/health
+```
+
+Learning note:
+
+Because this project currently uses `emptyDir`, deleting the Pod also deletes the SQLite data. This is why production apps should use a PersistentVolume or external database.
+
+## Exercise 8: Scale the App
+
+Goal: Learn replicas and the SQLite limitation.
+
+Scale:
+
+```bash
+kubectl scale deployment/url-shortener --replicas=3 -n url-shortener
+kubectl get pods -n url-shortener
+```
+
+Expected result:
+
+Three Pods run.
+
+Important project lesson:
+
+Each Pod gets its own `emptyDir` SQLite database. One request may create a short URL in Pod A, while a later redirect may land on Pod B and return `404`.
+
+Fix options:
+
+- For learning: scale back to one replica.
+- For a real project: move data to PostgreSQL and let every Pod use the same database.
+
+Scale back:
+
+```bash
+kubectl scale deployment/url-shortener --replicas=1 -n url-shortener
+```
+
+## Exercise 9: Resource Pressure
+
+Goal: Learn requests, limits, and scheduling.
+
+Break it by adding unrealistic resource requests to the container in `k8s/deployment.yaml`:
+
+```yaml
+resources:
+  requests:
+    cpu: "8"
+    memory: "16Gi"
+```
+
+Apply:
+
+```bash
+kubectl apply -f k8s/deployment.yaml
+kubectl get pods -n url-shortener
+kubectl describe pod <pod-name> -n url-shortener
+```
+
+Expected symptom:
+
+The Pod may stay `Pending`.
+
+Why it broke:
+
+Docker Desktop Kubernetes has limited CPU and memory. The scheduler cannot place a Pod that asks for more resources than the node can provide.
+
+Fix it with realistic values:
+
+```yaml
+resources:
+  requests:
+    cpu: "100m"
+    memory: "128Mi"
+  limits:
+    cpu: "500m"
+    memory: "512Mi"
+```
+
+Apply:
+
+```bash
+kubectl apply -f k8s/deployment.yaml
+kubectl rollout status deployment/url-shortener -n url-shortener
+```
+
+## Exercise 10: Roll Back a Bad Release
+
+Goal: Learn rollout history and undo.
+
+Create a bad release:
+
+```bash
+kubectl set image deployment/url-shortener url-shortener=url-shortener:bad -n url-shortener
+kubectl rollout status deployment/url-shortener -n url-shortener
+```
+
+Observe:
+
+```bash
+kubectl rollout history deployment/url-shortener -n url-shortener
+kubectl get pods -n url-shortener
+```
+
+Fix by rollback:
+
+```bash
+kubectl rollout undo deployment/url-shortener -n url-shortener
+kubectl rollout status deployment/url-shortener -n url-shortener
+curl http://localhost:30080/health
+```
+
+## Daily Debug Checklist
+
+Use this order when the app is broken:
+
+```bash
+kubectl get pods -n url-shortener
+kubectl describe pod <pod-name> -n url-shortener
+kubectl logs <pod-name> -n url-shortener
+kubectl get service,endpoints -n url-shortener
+kubectl describe service url-shortener -n url-shortener
+curl -v http://localhost:30080/health
+```
+
+Read the state first:
+
+- `Pending`: scheduler or resource issue.
+- `ImagePullBackOff` / `ErrImageNeverPull`: image issue.
+- `CrashLoopBackOff`: process starts and crashes.
+- `Running` with `READY 0/1`: readiness probe issue.
+- Service has no endpoints: selector or readiness issue.
+- Health works but redirect fails: application or database issue.
+
+## Suggested Learning Order
+
+1. Deploy the healthy app.
+2. Break image name.
+3. Break Service port.
+4. Break Service selector.
+5. Break readiness probe.
+6. Break liveness probe.
+7. Break database path.
+8. Delete Pods and watch self-healing.
+9. Scale replicas and discover the SQLite problem.
+10. Practice rollback.
+
+After you finish these, convert the SQLite database to PostgreSQL and repeat the same break/fix loop with a database `Service`, `Secret`, and `PersistentVolumeClaim`.

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: url-shortener
+  namespace: url-shortener
+  labels:
+    app: url-shortener
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: url-shortener
+  template:
+    metadata:
+      labels:
+        app: url-shortener
+    spec:
+      containers:
+        - name: url-shortener
+          image: url-shortener:dev
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 8000
+          env:
+            - name: DATABASE_URL
+              value: sqlite:////data/url_shortener.db
+          volumeMounts:
+            - name: sqlite-data
+              mountPath: /data
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 15
+            periodSeconds: 20
+      volumes:
+        - name: sqlite-data
+          emptyDir: {}

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: url-shortener

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: url-shortener
+  namespace: url-shortener
+spec:
+  type: NodePort
+  selector:
+    app: url-shortener
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+      nodePort: 30080


### PR DESCRIPTION
## Summary

Add Docker Desktop Kubernetes deployment support and documentation for using the FastAPI URL Shortener as a hands-on Kubernetes break/fix learning project.

## Related Issue

Closes #3

## Changes Made

- Added a `Dockerfile` for packaging the FastAPI app with Uvicorn.
- Added `.dockerignore` to keep local virtualenvs, caches, database files, and Git metadata out of the Docker build context.
- Added Kubernetes manifests under `k8s/`:
  - `namespace.yaml` creates the `url-shortener` namespace.
  - `deployment.yaml` runs the app using the local `url-shortener:dev` image.
  - `service.yaml` exposes the app through a Docker Desktop-friendly `NodePort` on `localhost:30080`.
- Added a `/health` endpoint in `app/main.py` for Kubernetes readiness and liveness probes.
- Added `deploy.md` with Docker Desktop Kubernetes deployment steps.
- Added `k8-learning.md` with a real-project Kubernetes break/fix learning path.

## Testing

Validated Python syntax locally with:

```bash
PYTHONPYCACHEPREFIX=/private/tmp/url_shortner_pycache python3 -m compileall app
```

Validated Kubernetes manifests with:

```bash
kubectl apply --dry-run=client --validate=false -f k8s
```

- [x] Unit tests pass
- [x] Manual testing completed
- [ ] API tested successfully
- [ ] UI flow verified

Tests note: the project does not currently include a dedicated test suite, so validation used Python compilation and Kubernetes dry-run checks.

## Screenshots / Evidence

Kubernetes dry-run output:

```text
deployment.apps/url-shortener created (dry run)
namespace/url-shortener created (dry run)
service/url-shortener created (dry run)
```

The app is documented to run at:

```text
http://localhost:30080
```

## Risk

Low to medium risk. The deployment setup is intended for Docker Desktop Kubernetes learning, not production.

Important notes:

- `emptyDir` storage is intentionally temporary and data is deleted when the Pod is deleted.
- `imagePullPolicy: Never` expects the image to be built locally as `url-shortener:dev`.
- Scaling beyond one replica exposes the SQLite limitation because each Pod has its own local data volume.
- Production deployments should use a `PersistentVolumeClaim` or an external database such as PostgreSQL.

## Checklist

- [x] Code follows the project structure
- [x] No secrets or sensitive data committed
- [ ] Tests added or updated where required
- [x] Documentation updated where required
- [x] PR is linked to the issue
- [x] Labels are applied
- [x] Assignee is added if possible
