### PR TITLE
chore: promote stage image publishing workflow

### DIFF
--- a/.github/instructions.md
+++ b/.github/instructions.md
@@ -208,7 +208,11 @@ For Docker Desktop Kubernetes:
   publish `sunlnx/url-shortener:dev_<short-sha>`.
 - Let Argo CD deploy `dev` branch changes to the `url-shortener-dev`
   namespace.
-- Deploy `stage` changes to the `url-shortener-stage` namespace.
+- Merge `dev` into `stage` and let
+  `.github/workflows/publish-stage-image.yml` publish
+  `sunlnx/url-shortener:stage_<short-sha>`.
+- Let Argo CD deploy `stage` branch changes to the `url-shortener-stage`
+  namespace.
 - Deploy the `master` commit to the `url-shortener-prod` namespace only after
   manual approval.
 

--- a/.github/workflows/publish-stage-image.yml
+++ b/.github/workflows/publish-stage-image.yml
@@ -1,0 +1,59 @@
+name: Publish Stage Image
+
+on:
+  push:
+    branches:
+      - stage
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  IMAGE_REPOSITORY: sunlnx/url-shortener
+  KUSTOMIZATION_PATH: k8s/environments/stage/kustomization.yaml
+
+jobs:
+  publish-stage-image:
+    name: Build, push, and update stage image tag
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.actor != 'github-actions[bot]'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: stage
+
+      - name: Set image tag
+        id: image
+        run: |
+          short_sha="$(git rev-parse --short HEAD)"
+          image_tag="stage_${short_sha}"
+          echo "IMAGE_TAG=${image_tag}" >> "$GITHUB_ENV"
+          echo "IMAGE_NAME=${IMAGE_REPOSITORY}:${image_tag}" >> "$GITHUB_ENV"
+          echo "tag=${image_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_LOGIN }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Build Docker image
+        run: docker build -t "${IMAGE_NAME}" .
+
+      - name: Push Docker image
+        run: docker push "${IMAGE_NAME}"
+
+      - name: Update stage Kustomize image tag
+        run: |
+          sed -i "s/newTag: .*/newTag: ${IMAGE_TAG}/" "${KUSTOMIZATION_PATH}"
+          git diff -- "${KUSTOMIZATION_PATH}"
+
+      - name: Commit image tag update
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          branch: stage
+          commit_message: "deploy(stage): update image tag to ${{ steps.image.outputs.tag }}"
+          file_pattern: k8s/environments/stage/kustomization.yaml

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ url_shortener/
 ├── .github/
 │   └── workflows/
 │       ├── ci.yml
-│       └── publish-dev-image.yml
+│       ├── publish-dev-image.yml
+│       └── publish-stage-image.yml
 ├── k8s/
 │   ├── base/
 │   │   ├── deployment.yaml
@@ -158,9 +159,9 @@ Stage and production local overlays are available through:
 
 ---
 
-## 🚢 Dev GitOps Deployment
+## 🚢 Dev And Stage GitOps Deployment
 
-The `dev` branch is deployed through Docker Hub and Argo CD.
+The `dev` and `stage` branches are deployed through Docker Hub and Argo CD.
 
 When a commit lands on `dev`, `.github/workflows/publish-dev-image.yml`:
 
@@ -172,6 +173,11 @@ When a commit lands on `dev`, `.github/workflows/publish-dev-image.yml`:
 
 Argo CD watches the `dev` branch and deploys the updated image to the
 `url-shortener-dev` namespace.
+
+When a commit lands on `stage`, `.github/workflows/publish-stage-image.yml`
+performs the same flow with the `stage_<short_commit_id>` tag, updates
+`k8s/environments/stage/kustomization.yaml`, and lets Argo CD deploy the stage
+overlay to the `url-shortener-stage` namespace.
 
 Required GitHub repository secrets:
 

--- a/docs/context/repository-context.md
+++ b/docs/context/repository-context.md
@@ -8,7 +8,7 @@ future contributors and agents can get oriented quickly.
 This repository contains a small FastAPI URL shortener backed by SQLite. It is
 structured as a learning-friendly service that demonstrates clean application
 layers, local Docker usage, Kubernetes deployment basics, automated tests, and
-CI quality checks, and a dev GitOps deployment flow using Docker Hub and
+CI quality checks, and dev/stage GitOps deployment flows using Docker Hub and
 Argo CD.
 
 ## Application Architecture
@@ -50,6 +50,8 @@ Key files:
   Kubernetes overlay to Docker Desktop after typed confirmation.
 - `.github/workflows/publish-dev-image.yml`: builds and pushes the dev Docker
   Hub image, then commits the new image tag back to `dev` for Argo CD.
+- `.github/workflows/publish-stage-image.yml`: builds and pushes the stage
+  Docker Hub image, then commits the new image tag back to `stage` for Argo CD.
 
 ## Runtime Behavior
 
@@ -108,6 +110,12 @@ It runs on pushes to `dev`, builds `sunlnx/url-shortener:dev_<short-sha>`,
 pushes it to Docker Hub, updates the dev Kustomize image tag, and commits that
 tag update back to `dev`.
 
+The stage image publishing workflow is
+`.github/workflows/publish-stage-image.yml`. It runs on pushes to `stage`,
+builds `sunlnx/url-shortener:stage_<short-sha>`, pushes it to Docker Hub,
+updates the stage Kustomize image tag, and commits that tag update back to
+`stage`.
+
 Required GitHub repository secrets for the Docker Hub push:
 
 - `DOCKER_HUB_LOGIN`: Docker Hub username.
@@ -115,7 +123,7 @@ Required GitHub repository secrets for the Docker Hub push:
 
 ## Deployment Notes
 
-The repository includes Docker, local Kubernetes support, and dev GitOps
+The repository includes Docker, local Kubernetes support, and dev/stage GitOps
 deployment:
 
 - `scripts/start.sh`: runs the local Uvicorn development server.
@@ -130,16 +138,18 @@ deployment:
 - `k8s/base/service.yaml`: exposes the app through a Docker Desktop NodePort.
 - `k8s/environments/dev`: targets Docker Hub image `sunlnx/url-shortener` for
   Argo CD deployment to `url-shortener-dev`.
-- `k8s/environments/stage` and
-  `k8s/environments/prod`: create environment namespaces and overlay
-  environment-specific settings.
-- Argo CD watches the `dev` branch and deploys the rendered dev overlay.
+- `k8s/environments/stage`: targets Docker Hub image `sunlnx/url-shortener` for
+  Argo CD deployment to `url-shortener-stage`.
+- `k8s/environments/prod`: creates the production namespace and overlays
+  production-specific settings.
+- Argo CD watches the `dev` branch for dev and the `stage` branch for staging.
 
 Current automation scope:
 
-- `dev` is automated through GitHub Actions, Docker Hub, and Argo CD.
-- `stage` and `prod` do not currently have image publishing workflows or Argo CD
-  applications documented in this repository.
+- `dev` and `stage` are automated through GitHub Actions, Docker Hub, and
+  Argo CD.
+- `prod` does not currently have an image publishing workflow or Argo CD
+  application documented in this repository.
 - The local deployment scripts are still useful for manual Docker Desktop
   testing because they build `url-shortener:dev` locally and override the
   Deployment image after applying the overlay.
@@ -174,6 +184,10 @@ Dev deployment expectations:
 - Let GitHub Actions publish `sunlnx/url-shortener:dev_<short-sha>`.
 - Let the workflow commit the updated dev image tag.
 - Let Argo CD sync the `dev` overlay into `url-shortener-dev`.
+- Promote `dev` into `stage`.
+- Let GitHub Actions publish `sunlnx/url-shortener:stage_<short-sha>`.
+- Let the workflow commit the updated stage image tag.
+- Let Argo CD sync the `stage` overlay into `url-shortener-stage`.
 - Use `scripts/deploy-*.sh` only for manual Docker Desktop local testing.
 
 ## Current Documentation Layout

--- a/docs/deployment/environment-promotion.md
+++ b/docs/deployment/environment-promotion.md
@@ -117,7 +117,7 @@ overlay.
 
 Keep the `kubectl port-forward` command running while you test the app.
 
-## Automatic Dev Image Publishing
+## Automatic Dev And Stage Image Publishing
 
 The workflow `.github/workflows/publish-dev-image.yml` builds and pushes a Docker
 Hub image when changes are pushed to `dev`.
@@ -133,7 +133,20 @@ After pushing the image, the workflow updates
 change back to `dev`. Argo CD watches the `dev` branch and deploys the updated
 image to the `url-shortener-dev` namespace.
 
-This workflow requires these GitHub repository secrets:
+The workflow `.github/workflows/publish-stage-image.yml` runs when changes are
+pushed to `stage`, including when a `dev -> stage` promotion PR is merged. It
+builds and pushes:
+
+```text
+sunlnx/url-shortener:stage_<short-commit-id>
+```
+
+After pushing the image, the workflow updates
+`k8s/environments/stage/kustomization.yaml` with the new tag and commits that
+change back to `stage`. Argo CD should watch the `stage` branch and deploy the
+updated stage overlay to the `url-shortener-stage` namespace.
+
+These workflows require these GitHub repository secrets:
 
 - `DOCKER_HUB_LOGIN`: Docker Hub username
 - `DOCKER_HUB_TOKEN`: Docker Hub access token or password

--- a/k8s/environments/dev/kustomization.yaml
+++ b/k8s/environments/dev/kustomization.yaml
@@ -12,4 +12,4 @@ patches:
 images:
   - name: url-shortener
     newName: sunlnx/url-shortener
-    newTag: dev_4fcb1ec
+    newTag: dev_ee687b3

--- a/k8s/environments/dev/kustomization.yaml
+++ b/k8s/environments/dev/kustomization.yaml
@@ -12,4 +12,4 @@ patches:
 images:
   - name: url-shortener
     newName: sunlnx/url-shortener
-    newTag: dev_ee687b3
+    newTag: dev_03e8210

--- a/k8s/environments/stage/kustomization.yaml
+++ b/k8s/environments/stage/kustomization.yaml
@@ -9,3 +9,7 @@ labels:
       environment: stage
 patches:
   - path: service-patch.yaml
+images:
+  - name: url-shortener
+    newName: sunlnx/url-shortener
+    newTag: stage_ee687b3


### PR DESCRIPTION
## Summary

Promote the stage image publishing workflow from `dev` to `stage` so staging can build, publish, and deploy its own Docker Hub image after this PR merges.

## Related Issue

Closes #21

> Note: GitHub auto-closes issues only when closing keywords reach the default branch, currently `master`. This promotion PR keeps the relationship visible for staging, and the later `stage -> master` promotion should include `Closes #21` again so GitHub closes the issue automatically.

## Changes Made

- Promotes `.github/workflows/publish-stage-image.yml` to the `stage` branch.
- Promotes Docker Hub image metadata for `k8s/environments/stage/kustomization.yaml`.
- Promotes documentation updates for dev and stage GitOps behavior.
- Includes the latest dev image tag update from the dev publishing workflow.

## Testing

Validated in PR #22 before merge to `dev`:

- [x] Unit tests pass
- [x] Manual testing completed
- [x] API tested successfully
- [x] UI flow verified

Commands run:

```text
ruby -e 'require "yaml"; ARGV.each { |file| YAML.load_file(file); puts "ok #{file}" }' .github/workflows/publish-dev-image.yml .github/workflows/publish-stage-image.yml\nkubectl kustomize k8s/environments/dev\nkubectl kustomize k8s/environments/stage\nkubectl kustomize k8s/environments/prod\ngit diff --check HEAD~1..HEAD\n```\n\n## Screenshots / Evidence\n\n```text\nok .github/workflows/publish-dev-image.yml\nok .github/workflows/publish-stage-image.yml\nStage render includes image: sunlnx/url-shortener:stage_ee687b3\n```\n\nExpected after this PR merges:\n\n```text\n.github/workflows/publish-stage-image.yml runs on the push to stage\nDocker image tag format: sunlnx/url-shortener:stage_<short-sha>\nStage overlay update path: k8s/environments/stage/kustomization.yaml\nDeployment namespace: url-shortener-stage\n```\n\n## Risk\n\nMedium. This promotion activates a new stage workflow on the `stage` branch. The workflow uses the same Docker Hub secrets and bot-loop guard as the dev workflow. Staging deployment still depends on Argo CD being configured to watch the `stage` branch and the stage overlay.\n\n## Checklist\n\n- [x] Code follows the project structure\n- [x] No secrets or sensitive data committed\n- [x] Tests added or updated where required\n- [x] Documentation updated where required\n- [x] PR is linked to the issue\n- [x] Labels are applied\n- [x] Assignee is added if possible