### PR TITLE
docs: promote prod branch clarification to stage

### DIFF
--- a/.github/instructions.md
+++ b/.github/instructions.md
@@ -188,6 +188,12 @@ Use this promotion flow for application changes:
 5. Deploy production only after the `stage` changes have reached `master` and
    explicit manual approval is given.
 
+In this repository, the production branch target is `master`. If a user says
+`prod branch`, `production branch`, or asks to promote production changes, treat
+that as `master` unless they explicitly ask for the legacy `prod` branch by
+name. Do not create `stage` to `prod` or `prod` to `master` promotion PRs for
+the normal flow; create `stage` to `master` instead.
+
 GitHub only auto-closes issues when a closing keyword reaches the repository
 default branch, currently `master`. Feature PRs into `dev` may still include
 `Closes #<issue-number>` for traceability, but every promotion PR into `master`
@@ -213,8 +219,8 @@ For Docker Desktop Kubernetes:
   `sunlnx/url-shortener:stage_<short-sha>`.
 - Let Argo CD deploy `stage` branch changes to the `url-shortener-stage`
   namespace.
-- Deploy the `master` commit to the `url-shortener-prod` namespace only after
-  manual approval.
+- Treat `master` as the production branch and deploy the `master` commit to the
+  `url-shortener-prod` namespace only after manual approval.
 
 Use `scripts/deploy-dev.sh`, `scripts/deploy-stage.sh`, and
 `scripts/deploy-prod.sh` only for manual local Docker Desktop testing. These

--- a/k8s/environments/dev/kustomization.yaml
+++ b/k8s/environments/dev/kustomization.yaml
@@ -12,4 +12,4 @@ patches:
 images:
   - name: url-shortener
     newName: sunlnx/url-shortener
-    newTag: dev_03e8210
+    newTag: dev_9c00c76


### PR DESCRIPTION
## Summary

Promote the production-branch wording clarification from `dev` to `stage`. This carries the instructions update that normal production promotion means `stage -> master`, plus the latest dev image tag produced after PR #27 merged.

## Related Issue

Closes #26

> Note: GitHub auto-closes issues only when closing keywords reach the default branch, currently `master`. This promotion keeps the relationship visible for staging, and the final `stage -> master` PR also includes `Closes #26`.

## Changes Made

- Promotes `.github/instructions.md` clarification that `prod branch` means `master` for the normal flow.
- Promotes the latest dev workflow image tag commit: `deploy(dev): update image tag to dev_9c00c76`.

## Testing

Validated in PR #27 before merge to `dev`:

- [x] Unit tests pass
- [x] Manual testing completed
- [x] API tested successfully
- [x] UI flow verified

Commands run:

```text
git diff --check
```

## Screenshots / Evidence

```text
PR #27 merged into dev at 2026-05-05T15:45:42Z
Dev workflow produced: deploy(dev): update image tag to dev_9c00c76
```

Expected after this PR merges:

```text
stage contains the updated production promotion instructions
.github/workflows/publish-stage-image.yml runs on the push to stage
```

## Risk

Low. The instructions change is documentation-only. The promotion also carries a normal dev image tag update, and the existing stage workflow may update the stage image tag after merge.

## Checklist

- [x] Code follows the project structure
- [x] No secrets or sensitive data committed
- [x] Tests added or updated where required
- [x] Documentation updated where required
- [x] PR is linked to the issue
- [x] Labels are applied
- [x] Assignee is added if possible