### PR TITLE
docs: promote README and branch naming updates to master

### DIFF
--- a/.github/instructions.md
+++ b/.github/instructions.md
@@ -440,10 +440,10 @@ Then explain that the GitHub connector or integration does not have enough permi
 In that case, provide manual PR steps:
 
 ```bash
-git checkout -b codex/<issue-number>-short-description
+git checkout -b feature/<issue-number>-short-description
 git add .
 git commit -m "<type>: <short summary>"
-git push origin codex/<issue-number>-short-description
+git push origin feature/<issue-number>-short-description
 ```
 
 Then ask the user to open the PR manually from GitHub.

--- a/.github/instructions.md
+++ b/.github/instructions.md
@@ -161,15 +161,15 @@ If assignee assignment fails due to permission issues, continue the workflow and
 Create a branch using this format:
 
 ```text
-codex/<issue-number>-short-description
+feature/<issue-number>-short-description
 ```
 
 Examples:
 
 ```text
-codex/12-fix-url-redirect
-codex/18-add-api-docs
-codex/25-refactor-database-layer
+feature/12-fix-url-redirect
+feature/18-add-api-docs
+feature/25-refactor-database-layer
 ```
 
 Use lowercase words separated by hyphens.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ url_shortener/
 * **ORM**: SQLAlchemy
 * **Frontend**: HTML (Jinja2 Templates)
 * **Server**: Uvicorn
+* **Quality**: pytest, coverage, Ruff
+* **Deployment**: Docker, Kustomize, Docker Desktop Kubernetes, GitHub Actions, Docker Hub, Argo CD
 
 ---
 
@@ -157,6 +159,14 @@ Stage and production local overlays are available through:
 ./scripts/deploy-prod.sh
 ```
 
+Local environment endpoints:
+
+```text
+dev:   http://localhost:30080
+stage: http://localhost:30081
+prod:  http://localhost:30082
+```
+
 ---
 
 ## 🚢 Dev And Stage GitOps Deployment
@@ -185,6 +195,40 @@ Required GitHub repository secrets:
 DOCKER_HUB_LOGIN
 DOCKER_HUB_TOKEN
 ```
+
+Production is represented by the `master` branch in this repository. Normal
+promotion flow is:
+
+```text
+feature/<issue-number>-short-description -> dev
+dev -> stage
+stage -> master
+```
+
+Production deployment still requires explicit manual approval before running
+`./scripts/deploy-prod.sh`.
+
+---
+
+## 🧪 Testing And CI
+
+Run the local test suite:
+
+```bash
+.venv/bin/python -m pytest -q
+```
+
+Run linting, formatting checks, and coverage:
+
+```bash
+.venv/bin/python -m ruff check .
+.venv/bin/python -m ruff format --check .
+.venv/bin/python -m pytest -q --cov=app --cov-report=term-missing --cov-report=xml
+```
+
+GitHub Actions runs `.github/workflows/ci.yml` on pushes and PRs. The workflow
+runs Ruff, pytest with coverage, uploads coverage artifacts, writes a job
+summary, and posts a sticky coverage comment on PRs.
 
 ---
 
@@ -295,16 +339,8 @@ Clicking the short URL redirects to the original URL.
 * Redis caching
 * Rate limiting
 * Authentication & user accounts
-* Kubernetes deployment (fits your learning path 🚀)
-
----
-
-## 🧪 Testing Ideas
-
-* Test duplicate URL handling
-* Test invalid URL input
-* Test redirect functionality
-* Load test short URL generation
+* Production-ready persistent storage or an external database
+* Ingress, TLS, and cloud Kubernetes deployment
 
 ---
 
@@ -316,17 +352,6 @@ Additional project notes are organized under `docs/`:
 * [Docker Desktop Kubernetes deployment](docs/deployment/docker-desktop-kubernetes.md)
 * [Environment promotion flow](docs/deployment/environment-promotion.md)
 * [Kubernetes break/fix learning path](docs/learning/kubernetes-break-fix.md)
-
----
-
-## 📦 Deployment Ideas
-
-* Dockerize the app
-* Deploy on:
-
-  * AWS EC2 / ECS
-  * IBM Cloud Code Engine
-  * Kubernetes (Ingress + Service)
 
 ---
 

--- a/docs/context/repository-context.md
+++ b/docs/context/repository-context.md
@@ -148,8 +148,8 @@ Current automation scope:
 
 - `dev` and `stage` are automated through GitHub Actions, Docker Hub, and
   Argo CD.
-- `prod` does not currently have an image publishing workflow or Argo CD
-  application documented in this repository.
+- `master` is the production branch for normal promotion. Production deployment
+  is manual and targets the `url-shortener-prod` namespace.
 - The local deployment scripts are still useful for manual Docker Desktop
   testing because they build `url-shortener:dev` locally and override the
   Deployment image after applying the overlay.
@@ -173,14 +173,14 @@ The repository instructions live in `.github/instructions.md`.
 Important workflow expectations:
 
 - Create or use a GitHub issue before implementation work.
-- Use branches named `codex/<issue-number>-short-description`.
+- Use branches named `feature/<issue-number>-short-description`.
 - Keep PR descriptions structured with summary, testing, risk, and checklist.
 - Apply labels and assignees when possible.
 - Do not run `git push` without explicit user approval.
 
-Dev deployment expectations:
+Promotion and deployment expectations:
 
-- Merge feature PRs into `dev`.
+- Merge `feature/**` PRs into `dev`.
 - Let GitHub Actions publish `sunlnx/url-shortener:dev_<short-sha>`.
 - Let the workflow commit the updated dev image tag.
 - Let Argo CD sync the `dev` overlay into `url-shortener-dev`.
@@ -188,6 +188,9 @@ Dev deployment expectations:
 - Let GitHub Actions publish `sunlnx/url-shortener:stage_<short-sha>`.
 - Let the workflow commit the updated stage image tag.
 - Let Argo CD sync the `stage` overlay into `url-shortener-stage`.
+- Promote `stage` into `master`.
+- Treat `master` as the production branch; deploy to `url-shortener-prod` only
+  after explicit manual approval.
 - Use `scripts/deploy-*.sh` only for manual Docker Desktop local testing.
 
 ## Current Documentation Layout

--- a/docs/context/repository-context.md
+++ b/docs/context/repository-context.md
@@ -200,6 +200,7 @@ docs/
 ├── context/
 │   └── repository-context.md
 ├── deployment/
+│   ├── argocd-install.md
 │   ├── docker-desktop-kubernetes.md
 │   └── environment-promotion.md
 └── learning/

--- a/docs/deployment/argocd-install.md
+++ b/docs/deployment/argocd-install.md
@@ -1,0 +1,219 @@
+# Install Argo CD On Docker Desktop Kubernetes
+
+Use this guide to install Argo CD into Docker Desktop Kubernetes and connect it
+to this repository's `dev` and `stage` GitOps overlays.
+
+## Prerequisites
+
+1. Install Docker Desktop.
+2. Enable Kubernetes in Docker Desktop.
+3. Install `kubectl`.
+4. Confirm your Kubernetes context points to Docker Desktop:
+
+```bash
+kubectl config current-context
+```
+
+Expected context:
+
+```text
+docker-desktop
+```
+
+If needed:
+
+```bash
+kubectl config use-context docker-desktop
+```
+
+## 1. Install Argo CD
+
+Create the Argo CD namespace and apply the official stable install manifest:
+
+```bash
+kubectl create namespace argocd
+kubectl apply -n argocd --server-side --force-conflicts \
+  -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+```
+
+Wait for Argo CD to become ready:
+
+```bash
+kubectl rollout status deployment/argocd-server -n argocd
+kubectl rollout status deployment/argocd-repo-server -n argocd
+kubectl rollout status deployment/argocd-applicationset-controller -n argocd
+kubectl rollout status statefulset/argocd-application-controller -n argocd
+```
+
+Check the installed resources:
+
+```bash
+kubectl get pods -n argocd
+kubectl get svc -n argocd
+```
+
+## 2. Install The Argo CD CLI
+
+On macOS with Homebrew:
+
+```bash
+brew install argocd
+```
+
+Confirm the CLI works:
+
+```bash
+argocd version --client
+```
+
+## 3. Open The Argo CD UI
+
+Argo CD is not exposed outside the cluster by default. Use port forwarding for
+local Docker Desktop access:
+
+```bash
+kubectl port-forward svc/argocd-server -n argocd 8080:443
+```
+
+Keep that terminal open, then open:
+
+```text
+https://localhost:8080
+```
+
+The browser may warn about a self-signed certificate. That is expected for this
+local install.
+
+## 4. Log In
+
+Get the initial admin password:
+
+```bash
+kubectl get secret argocd-initial-admin-secret -n argocd \
+  -o jsonpath="{.data.password}" | base64 -d
+```
+
+Log in with the CLI:
+
+```bash
+argocd login localhost:8080 --username admin --password <password> --insecure
+```
+
+After logging in, change the admin password:
+
+```bash
+argocd account update-password
+```
+
+## 5. Create The Dev Application
+
+Create an Argo CD Application that watches the `dev` branch and applies the dev
+Kustomize overlay:
+
+```bash
+argocd app create url-shortener-dev \
+  --repo https://github.com/samperay/url_shortner.git \
+  --revision dev \
+  --path k8s/environments/dev \
+  --dest-server https://kubernetes.default.svc \
+  --dest-namespace url-shortener-dev \
+  --sync-policy automated \
+  --auto-prune \
+  --self-heal
+```
+
+Sync it:
+
+```bash
+argocd app sync url-shortener-dev
+argocd app wait url-shortener-dev --health --sync
+```
+
+Verify the app:
+
+```bash
+kubectl port-forward svc/url-shortener 30080:80 -n url-shortener-dev
+curl http://localhost:30080/health
+```
+
+Expected response:
+
+```json
+{"status":"ok"}
+```
+
+## 6. Create The Stage Application
+
+Create an Argo CD Application that watches the `stage` branch and applies the
+stage Kustomize overlay:
+
+```bash
+argocd app create url-shortener-stage \
+  --repo https://github.com/samperay/url_shortner.git \
+  --revision stage \
+  --path k8s/environments/stage \
+  --dest-server https://kubernetes.default.svc \
+  --dest-namespace url-shortener-stage \
+  --sync-policy automated \
+  --auto-prune \
+  --self-heal
+```
+
+Sync it:
+
+```bash
+argocd app sync url-shortener-stage
+argocd app wait url-shortener-stage --health --sync
+```
+
+Verify the app:
+
+```bash
+kubectl port-forward svc/url-shortener 30081:80 -n url-shortener-stage
+curl http://localhost:30081/health
+```
+
+Expected response:
+
+```json
+{"status":"ok"}
+```
+
+## 7. How The GitOps Flow Works
+
+After Argo CD is installed and both Applications exist:
+
+- A merge to `dev` triggers `.github/workflows/publish-dev-image.yml`.
+- The workflow pushes `sunlnx/url-shortener:dev_<short-sha>` to Docker Hub.
+- The workflow updates `k8s/environments/dev/kustomization.yaml` on `dev`.
+- Argo CD sees the `dev` branch change and syncs `url-shortener-dev`.
+- A merge to `stage` triggers `.github/workflows/publish-stage-image.yml`.
+- The workflow pushes `sunlnx/url-shortener:stage_<short-sha>` to Docker Hub.
+- The workflow updates `k8s/environments/stage/kustomization.yaml` on `stage`.
+- Argo CD sees the `stage` branch change and syncs `url-shortener-stage`.
+
+Production remains manual for this Docker Desktop setup. See
+[Environment promotion flow](environment-promotion.md) for the promotion model.
+
+## Troubleshooting
+
+If the Argo CD UI does not open, confirm the port-forward is still running:
+
+```bash
+kubectl port-forward svc/argocd-server -n argocd 8080:443
+```
+
+If an Application cannot fetch the repository, confirm the repository is public.
+For a private repository, add repository credentials in Argo CD before creating
+the Applications.
+
+If an Application is out of sync, inspect it:
+
+```bash
+argocd app get url-shortener-dev
+argocd app diff url-shortener-dev
+```
+
+If a synced app is not reachable locally, use `kubectl port-forward` instead of
+NodePort access. Docker Desktop on macOS may not expose NodePort traffic
+reliably on `localhost`.

--- a/docs/deployment/docker-desktop-kubernetes.md
+++ b/docs/deployment/docker-desktop-kubernetes.md
@@ -203,6 +203,9 @@ This also deletes the `emptyDir` SQLite data.
 For stage and production environment commands, see
 [Environment promotion flow](environment-promotion.md).
 
+For GitOps deployment through Argo CD, see
+[Install Argo CD on Docker Desktop Kubernetes](argocd-install.md).
+
 ## 7. Next Production Improvements
 
 - Replace `emptyDir` with a `PersistentVolumeClaim`.

--- a/docs/deployment/environment-promotion.md
+++ b/docs/deployment/environment-promotion.md
@@ -12,6 +12,8 @@ For now these environments target Docker Desktop Kubernetes. Later, the same
 layout can be pointed at a cloud Kubernetes cluster by changing image publishing
 and cluster credentials, while keeping the promotion model.
 
+For one-time Argo CD setup, see [Install Argo CD on Docker Desktop Kubernetes](argocd-install.md).
+
 ## One-Time Branch Setup
 
 If the `dev` and `stage` branches do not exist yet, create them from
@@ -154,6 +156,10 @@ These workflows require these GitHub repository secrets:
 The local deployment scripts are still for Docker Desktop-only manual testing.
 They build `url-shortener:dev`, apply the selected overlay, and override the
 Deployment to use the local Docker Desktop image.
+
+Argo CD itself must be installed once in the cluster, and the dev/stage
+Applications must be created before the branch watcher flow can sync changes.
+See [Install Argo CD on Docker Desktop Kubernetes](argocd-install.md).
 
 ## Health Checks
 

--- a/k8s/environments/dev/kustomization.yaml
+++ b/k8s/environments/dev/kustomization.yaml
@@ -12,4 +12,4 @@ patches:
 images:
   - name: url-shortener
     newName: sunlnx/url-shortener
-    newTag: dev_9c00c76
+    newTag: dev_78ac845

--- a/k8s/environments/stage/kustomization.yaml
+++ b/k8s/environments/stage/kustomization.yaml
@@ -12,4 +12,4 @@ patches:
 images:
   - name: url-shortener
     newName: sunlnx/url-shortener
-    newTag: stage_bf70321
+    newTag: stage_b30c0c1


### PR DESCRIPTION
## Summary

Promote PR #31 and the staged environment updates from `stage` to `master`. This makes the default branch current with the README/context refresh, `feature/**` branch naming guidance, Argo CD documentation updates, and the latest dev/stage image tags.

## Related Issue

Closes #30

## Changes Made

- Promotes `.github/instructions.md` branch naming updates from `codex/**` to `feature/**`.
- Promotes README and repository context refreshes for CI, testing, Kubernetes, GitOps, and promotion flow.
- Promotes Argo CD deployment documentation updates.
- Promotes latest dev image tag update: `dev_78ac845`.
- Promotes latest stage image tag update: `stage_b30c0c1`.

## Testing

Validated in PR #31 before merge to `dev`, then promoted through PR #32 into `stage`:

- [x] Unit tests pass
- [x] Manual testing completed
- [x] API tested successfully
- [x] UI flow verified

Commands run:

```text
git diff --check
rg -n "codex/<issue|codex/[0-9]|git checkout -b codex|git push origin codex" .github/instructions.md README.md docs/context/repository-context.md
```

## Screenshots / Evidence

```text
PR #31 merged into dev at 2026-05-06T05:16:40Z
Dev workflow produced: deploy(dev): update image tag to dev_78ac845
PR #32 merged into stage
Stage workflow produced: deploy(stage): update image tag to stage_b30c0c1
```

Expected after this PR merges:

```text
master contains the latest README/context and feature branch naming guidance
GitHub auto-closes issue #30 because this PR targets the default branch
Normal future promotion flow remains feature/** -> dev -> stage -> master
```

## Risk

Low. Documentation-focused promotion plus normal dev/stage image tag updates produced by existing workflows. No app runtime behavior changes.

## Checklist

- [x] Code follows the project structure
- [x] No secrets or sensitive data committed
- [x] Tests added or updated where required
- [x] Documentation updated where required
- [x] PR is linked to the issue
- [x] Labels are applied
- [x] Assignee is added if possible