### PR TITLE
docs: add Argo CD GitOps break-fix guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,11 @@ url_shortener/
 │   ├── context/
 │   │   └── repository-context.md
 │   ├── deployment/
+│   │   ├── argocd-install.md
 │   │   ├── docker-desktop-kubernetes.md
 │   │   └── environment-promotion.md
 │   └── learning/
+│       ├── gitops-argocd-break-fix.md
 │       └── kubernetes-break-fix.md
 ├── .github/
 │   └── workflows/
@@ -349,8 +351,10 @@ Clicking the short URL redirects to the original URL.
 Additional project notes are organized under `docs/`:
 
 * [Repository context](docs/context/repository-context.md)
+* [Install Argo CD on Docker Desktop Kubernetes](docs/deployment/argocd-install.md)
 * [Docker Desktop Kubernetes deployment](docs/deployment/docker-desktop-kubernetes.md)
 * [Environment promotion flow](docs/deployment/environment-promotion.md)
+* [GitOps and Argo CD break/fix learning path](docs/learning/gitops-argocd-break-fix.md)
 * [Kubernetes break/fix learning path](docs/learning/kubernetes-break-fix.md)
 
 ---

--- a/docs/context/repository-context.md
+++ b/docs/context/repository-context.md
@@ -164,7 +164,7 @@ Local access:
 Deployment docs are grouped under `docs/deployment/`. The Kubernetes layout uses
 a reusable `k8s/base/` manifest and environment overlays under
 `k8s/environments/` for `dev`, `stage`, and `prod`.
-Kubernetes learning exercises are grouped under `docs/learning/`.
+Kubernetes and GitOps learning exercises are grouped under `docs/learning/`.
 
 ## Repository Workflow
 
@@ -204,6 +204,7 @@ docs/
 │   ├── docker-desktop-kubernetes.md
 │   └── environment-promotion.md
 └── learning/
+    ├── gitops-argocd-break-fix.md
     └── kubernetes-break-fix.md
 ```
 

--- a/docs/learning/gitops-argocd-break-fix.md
+++ b/docs/learning/gitops-argocd-break-fix.md
@@ -1,0 +1,332 @@
+# GitOps And Argo CD Break/Fix Learning Path
+
+Use this guide after installing Argo CD with
+[Install Argo CD on Docker Desktop Kubernetes](../deployment/argocd-install.md).
+The goal is to learn GitOps by breaking the live Argo CD flow for this URL
+Shortener app, reading the symptoms, and fixing the source of truth.
+
+## Starting Point
+
+Confirm both Argo CD Applications exist and are healthy:
+
+```bash
+argocd app get url-shortener-dev
+argocd app get url-shortener-stage
+```
+
+Expected status for each app:
+
+```text
+Sync Status: Synced
+Health Status: Healthy
+```
+
+Verify the Kubernetes side:
+
+```bash
+kubectl get pods -n url-shortener-dev
+kubectl get pods -n url-shortener-stage
+```
+
+Verify the app endpoints with port-forwarding:
+
+```bash
+kubectl port-forward svc/url-shortener 30080:80 -n url-shortener-dev
+curl http://localhost:30080/health
+```
+
+In another terminal:
+
+```bash
+kubectl port-forward svc/url-shortener 30081:80 -n url-shortener-stage
+curl http://localhost:30081/health
+```
+
+Expected response:
+
+```json
+{"status":"ok"}
+```
+
+## Learning Loop
+
+For each exercise:
+
+1. Break one part of the GitOps flow.
+2. Observe the symptom in Argo CD and Kubernetes.
+3. Explain whether the problem is Git state, cluster drift, image publishing, or
+   Application configuration.
+4. Fix the source of truth or the Argo CD Application.
+5. Confirm Argo CD returns to `Synced` and `Healthy`.
+
+Prefer fixing files and PRs over manually patching the cluster. Manual cluster
+changes are useful for learning drift, but Git should remain the long-term
+source of truth.
+
+## Exercise 1: Manual Cluster Drift And Self-Heal
+
+Goal: Learn how Argo CD detects and repairs drift when `self-heal` is enabled.
+
+Break it:
+
+```bash
+kubectl scale deployment/url-shortener --replicas=2 -n url-shortener-dev
+kubectl get deployment/url-shortener -n url-shortener-dev
+```
+
+Observe:
+
+```bash
+argocd app get url-shortener-dev
+argocd app diff url-shortener-dev
+kubectl get deployment/url-shortener -n url-shortener-dev --watch
+```
+
+Expected symptom:
+
+```text
+OutOfSync
+```
+
+Why it broke:
+
+The live cluster was changed directly. Git still says the Deployment should use
+the replica count from `k8s/environments/dev`, so Argo CD sees drift.
+
+Fix it:
+
+If self-heal is enabled, wait for Argo CD to restore the Git-defined state. If
+you want to force the repair:
+
+```bash
+argocd app sync url-shortener-dev
+argocd app wait url-shortener-dev --health --sync
+```
+
+Confirm:
+
+```bash
+argocd app get url-shortener-dev
+kubectl get deployment/url-shortener -n url-shortener-dev
+```
+
+## Exercise 2: Pause Auto-Sync
+
+Goal: Learn the difference between committed Git changes and Argo CD sync
+policy.
+
+Break it:
+
+```bash
+argocd app set url-shortener-dev --sync-policy none
+```
+
+Make a small documentation-only PR into `dev`, or wait for an existing dev image
+tag update. Then inspect:
+
+```bash
+argocd app get url-shortener-dev
+argocd app diff url-shortener-dev
+```
+
+Expected symptom:
+
+```text
+OutOfSync
+```
+
+Why it broke:
+
+Argo CD can see that Git changed, but auto-sync is disabled, so it does not
+apply the desired state.
+
+Fix it:
+
+```bash
+argocd app set url-shortener-dev --sync-policy automated --auto-prune --self-heal
+argocd app sync url-shortener-dev
+argocd app wait url-shortener-dev --health --sync
+```
+
+## Exercise 3: Wrong Application Path
+
+Goal: Learn how an Application points to a Git path.
+
+Break it:
+
+```bash
+argocd app set url-shortener-stage --path k8s/environments/missing
+```
+
+Observe:
+
+```bash
+argocd app get url-shortener-stage
+argocd app events url-shortener-stage
+```
+
+Expected symptom:
+
+```text
+ComparisonError
+```
+
+Why it broke:
+
+The Argo CD Application now points at a path that does not exist in the
+repository, so Argo CD cannot generate manifests.
+
+Fix it:
+
+```bash
+argocd app set url-shortener-stage --path k8s/environments/stage
+argocd app sync url-shortener-stage
+argocd app wait url-shortener-stage --health --sync
+```
+
+## Exercise 4: Wrong Branch Revision
+
+Goal: Learn how branch selection controls the desired state.
+
+Break it:
+
+```bash
+argocd app set url-shortener-stage --revision dev
+```
+
+Observe:
+
+```bash
+argocd app get url-shortener-stage
+argocd app diff url-shortener-stage
+```
+
+Expected symptom:
+
+The stage Application starts comparing the cluster against the `dev` branch
+instead of the `stage` branch.
+
+Why it broke:
+
+GitOps depends on the Application watching the correct revision. This repository
+expects:
+
+```text
+url-shortener-dev   -> dev
+url-shortener-stage -> stage
+```
+
+Fix it:
+
+```bash
+argocd app set url-shortener-stage --revision stage
+argocd app sync url-shortener-stage
+argocd app wait url-shortener-stage --health --sync
+```
+
+## Exercise 5: Bad Image Tag In Git
+
+Goal: Learn the difference between a GitOps sync problem and an image pull
+problem.
+
+Break it on a short-lived feature branch by editing
+`k8s/environments/dev/kustomization.yaml`:
+
+```yaml
+images:
+  - name: url-shortener
+    newName: sunlnx/url-shortener
+    newTag: dev_missing
+```
+
+Promote that change to `dev` only if you intentionally want to see the failure
+in Argo CD.
+
+Observe:
+
+```bash
+argocd app get url-shortener-dev
+kubectl get pods -n url-shortener-dev
+kubectl describe pod <pod-name> -n url-shortener-dev
+```
+
+Expected symptom:
+
+```text
+ImagePullBackOff
+```
+
+Why it broke:
+
+Argo CD successfully synced the manifests from Git, but Kubernetes cannot pull
+the image tag. The sync can be `Synced` while health is degraded.
+
+Fix it:
+
+Revert the bad tag or let `.github/workflows/publish-dev-image.yml` write a real
+`dev_<short-sha>` tag after the next merge to `dev`.
+
+Confirm:
+
+```bash
+argocd app sync url-shortener-dev
+argocd app wait url-shortener-dev --health --sync
+curl http://localhost:30080/health
+```
+
+## Exercise 6: Recover From A Failed Stage Promotion
+
+Goal: Practice reading the full GitHub Actions to Argo CD pipeline.
+
+Break it:
+
+1. Create a temporary branch with a harmless docs change.
+2. Open and merge the PR into `dev`.
+3. Confirm the dev image workflow updates the dev tag.
+4. Promote `dev -> stage`.
+5. Watch the stage image workflow and Argo CD stage Application.
+
+Observe each layer:
+
+```bash
+gh run list --branch dev --limit 5
+gh run list --branch stage --limit 5
+argocd app get url-shortener-stage
+argocd app diff url-shortener-stage
+kubectl get pods -n url-shortener-stage
+```
+
+Expected healthy path:
+
+```text
+dev merge -> dev image tag commit -> dev Argo CD sync
+stage promotion -> stage image tag commit -> stage Argo CD sync
+```
+
+If it fails, decide where the break happened:
+
+- GitHub Actions failed before pushing an image.
+- The workflow pushed an image but did not update Kustomize.
+- Argo CD is not watching the expected branch/path.
+- Kubernetes synced the manifests but the Pod is unhealthy.
+
+Fix it by repairing the failed layer, then confirm:
+
+```bash
+argocd app wait url-shortener-stage --health --sync
+curl http://localhost:30081/health
+```
+
+## Cleanup Checklist
+
+After break/fix practice:
+
+```bash
+argocd app get url-shortener-dev
+argocd app get url-shortener-stage
+kubectl get pods -n url-shortener-dev
+kubectl get pods -n url-shortener-stage
+```
+
+Both Applications should be `Synced` and `Healthy`, and both namespaces should
+have a running `url-shortener` Pod.

--- a/docs/learning/kubernetes-break-fix.md
+++ b/docs/learning/kubernetes-break-fix.md
@@ -2,6 +2,11 @@
 
 Use this file as a hands-on tutorial for learning Kubernetes by breaking this real URL Shortener app and fixing it again.
 
+If you want to practice GitOps behavior after the Kubernetes basics, continue
+with [GitOps and Argo CD break/fix learning path](gitops-argocd-break-fix.md).
+That guide uses Argo CD sync, drift, self-heal, branch, path, and image-tag
+failures to teach the dev/stage GitOps flow.
+
 Start from a healthy deployment:
 
 ```bash


### PR DESCRIPTION
## Summary

Add a hands-on GitOps and Argo CD break/fix learning path for the URL Shortener dev/stage flow. The new guide connects the Argo CD install docs with practical exercises for sync, drift, self-heal, branch/path mistakes, image tag failures, and stage promotion troubleshooting.

## Related Issue

Closes #34

> Note: GitHub auto-closes issues only when closing keywords reach the default branch, currently `master`. This PR targets `dev` for the normal feature flow, and the closing keyword should be carried forward on the later `stage -> master` promotion PR.

## Changes Made

- Added `docs/learning/gitops-argocd-break-fix.md` with six Argo CD/GitOps break-fix exercises.
- Linked the new guide from `docs/learning/kubernetes-break-fix.md`.
- Updated README documentation tree and links for Argo CD install and GitOps learning.
- Updated repository context to include GitOps learning docs.

## Testing

- [x] Unit tests pass
- [x] Manual testing completed
- [x] API tested successfully
- [x] UI flow verified

Commands run:

```text
git diff --check
rg -n "argocd-install|gitops-argocd-break-fix|Kubernetes and GitOps" README.md docs/context/repository-context.md docs/learning/kubernetes-break-fix.md docs/learning/gitops-argocd-break-fix.md
```

## Screenshots / Evidence

```text
git diff --check completed with no whitespace errors.
New guide: docs/learning/gitops-argocd-break-fix.md
README and repository context include the new learning path.
```

## Risk

Low. Documentation-only learning path update. No app, workflow, Kubernetes manifest, or runtime behavior changes.

## Checklist

- [x] Code follows the project structure
- [x] No secrets or sensitive data committed
- [x] Tests added or updated where required
- [x] Documentation updated where required
- [x] PR is linked to the issue
- [x] Labels are applied
- [x] Assignee is added if possible